### PR TITLE
Use error-first callback to simplify error handling

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -52,24 +52,28 @@ function getFeed (urlfeed, callback) {
 			}
 		});
 	feedparser.on ("end", function () {
-		callback (feedItems);
+		callback (null, feedItems);
 		});
-	feedparser.on ("error", function () {
-		console.log ("getFeed: Error reading feed.");
-		callback (undefined);
+	feedparser.on ("error", function (error) {
+		callback (error);
 		});
 	}
 
-getFeed (urlTestFeed, function (feedItems) {
-	console.log ("There are " + feedItems.length + " items in the feed.\n");
-	function pad (num) { 
-		var s = num.toString (), ctplaces = 3;
-		while (s.length < ctplaces) {
-			s = "0" + s;
-			}
-		return (s);
+getFeed (urlTestFeed, function (error, feedItems) {
+	if (error) {
+		console.log ("getFeed: Error reading feed.");
 		}
-	for (var i = 0; i < feedItems.length; i++) {
-		console.log ("Item #" + pad (i) + ": " + feedItems [i].title + ".\n");
+	else {
+		console.log ("There are " + feedItems.length + " items in the feed.\n");
+		function pad (num) { 
+			var s = num.toString (), ctplaces = 3;
+			while (s.length < ctplaces) {
+				s = "0" + s;
+				}
+			return (s);
+			}
+		for (var i = 0; i < feedItems.length; i++) {
+			console.log ("Item #" + pad (i) + ": " + feedItems [i].title + ".\n");
+			}		
 		}
 	});


### PR DESCRIPTION
Currently, we try to log "There are " + `feedItems.length` + " items in the feed.", but in the case of an error, `feedItems` would be undefined, and so calling `feedItems.length` would cause a TypeError to be thrown.

To address it, let's follow node's error-first callback convention, and in our callback, we'll handle the error case and the success case with an if/else block.